### PR TITLE
StartedBy property

### DIFF
--- a/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
@@ -1637,15 +1637,6 @@ namespace Microsoft.Azure.Commands.Automation.Common
                     string.Format(CultureInfo.CurrentCulture, Resources.InvalidRunbookParameters));
             }
 
-            var hasJobStartedBy =
-                filteredParameters.Any(filteredParameter => filteredParameter.Key == Constants.JobStartedByParameterName);
-
-            if (!hasJobStartedBy)
-            {
-                filteredParameters.Add(Constants.JobStartedByParameterName,
-                    PowerShellJsonConverter.Serialize(Constants.ClientIdentity));
-            }
-
             return filteredParameters;
         }
 

--- a/src/ResourceManager/Automation/Commands.Automation/Model/Job.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Model/Job.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.Commands.Automation.Model
             this.EndTime = job.Properties.EndTime.HasValue ? job.Properties.EndTime.Value.ToLocalTime() : (DateTimeOffset?) null;
             this.LastStatusModifiedTime = job.Properties.LastStatusModifiedTime;
             this.HybridWorker = job.Properties.RunOn;
+            this.StartedBy = job.Properties.StartedBy;
             this.JobParameters = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
             foreach (var kvp in job.Properties.Parameters) 
             {
@@ -161,5 +162,10 @@ namespace Microsoft.Azure.Commands.Automation.Model
         /// Gets or sets the HybridWorker.
         /// </summary>
         public string HybridWorker { get; set; }
+
+        /// <summary>
+        /// Gets or sets the StartedBy property.
+        /// </summary>
+        public string StartedBy { get; set; }
     }
 }


### PR DESCRIPTION
Adding and populating the Job StartedBy property. Removing the obsolete StartedBy parameter addition code for registering a schedule, creating/updating a webhook and starting a runbook.