### PR TITLE
New-AzureRmAutomationSchedule cmdlet will convert times into the specified time zone

### DIFF
--- a/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
@@ -340,10 +340,20 @@ namespace Microsoft.Azure.Commands.Automation.Common
                 }
             };
 
-            var scheduleCreateResponse = this.automationManagementClient.Schedules.CreateOrUpdate(
-                resourceGroupName,
-                automationAccountName,
-                scheduleCreateOrUpdateParameters);
+            if (!string.IsNullOrEmpty(schedule.TimeZone))
+            {
+                this.automationManagementClient.Schedules.CreateOrUpdateWithTimeConversion(
+                    resourceGroupName,
+                    automationAccountName,
+                    scheduleCreateOrUpdateParameters);
+            }
+            else
+            {
+                this.automationManagementClient.Schedules.CreateOrUpdate(
+                    resourceGroupName,
+                    automationAccountName,
+                    scheduleCreateOrUpdateParameters);
+            }
 
             return this.GetSchedule(resourceGroupName, automationAccountName, schedule.Name);
         }


### PR DESCRIPTION
Modifying the AutomationClient so that New-AzureRmAutomationSchedule
cmdlet will convert times into the specified time zone whenever a time
zone is specified.