### PR TITLE
Update schedule

### DIFF
--- a/src/ResourceManager/Automation/Commands.Automation/Cmdlet/SetAzureAutomationSchedule.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Cmdlet/SetAzureAutomationSchedule.cs
@@ -12,10 +12,15 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using System;
+using System.Linq;
 using Microsoft.Azure.Commands.Automation.Common;
-using Microsoft.Azure.Commands.Automation.Model;
+using Microsoft.Azure.Commands.Automation.Properties;
 using System.Management.Automation;
 using System.Security.Permissions;
+using Microsoft.Azure.Management.Automation.Models;
+using Schedule = Microsoft.Azure.Commands.Automation.Model.Schedule;
+using ScheduleFrequency = Microsoft.Azure.Commands.Automation.Model.ScheduleFrequency;
 
 namespace Microsoft.Azure.Commands.Automation.Cmdlet
 {
@@ -29,7 +34,7 @@ namespace Microsoft.Azure.Commands.Automation.Cmdlet
         /// <summary>
         /// Gets or sets the schedule name.
         /// </summary>
-        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByName, Position = 2, Mandatory = true, ValueFromPipelineByPropertyName = true,
+        [Parameter(Position = 2, Mandatory = true, ValueFromPipelineByPropertyName = true,
             HelpMessage = "The schedule name.")]
         [ValidateNotNullOrEmpty]
         public string Name { get; set; }
@@ -49,14 +54,242 @@ namespace Microsoft.Azure.Commands.Automation.Cmdlet
         public string Description { get; set; }
 
         /// <summary>
+        /// Gets or sets the schedule start time.
+        /// </summary>
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "The schedule start time.")]
+        public DateTimeOffset? StartTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule days of the week.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByWeekly, Mandatory = false, HelpMessage = "The list of days of week for the weekly schedule.")]
+        public System.DayOfWeek[] DaysOfWeek { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule days of the month.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByMonthlyDaysOfMonth, Mandatory = false, HelpMessage = "The list of days of month for the monthly schedule.")]
+        public DaysOfMonth[] DaysOfMonth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule day of the week.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByMonthlyDayOfWeek, Mandatory = false, HelpMessage = "The day of week for the monthly occurrence.")]
+        public System.DayOfWeek? DayOfWeek { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule day of the week.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByMonthlyDayOfWeek, Mandatory = false, HelpMessage = "The Occurrence of the week within the month.")]
+        public DayOfWeekOccurrence DayOfWeekOccurrence { get; set; }
+
+        /// <summary>
+        /// Gets or sets the switch parameter to create a one time schedule.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByOneTime, Mandatory = true, HelpMessage = "To create a one time schedule.")]
+        public SwitchParameter OneTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule expiry time.
+        /// </summary>
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "The schedule expiry time.")]
+        public DateTimeOffset? ExpiryTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the daily schedule day interval.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByDaily, Mandatory = true, HelpMessage = "The daily schedule day interval.")]
+        [ValidateRange(1, byte.MaxValue)]
+        public byte DayInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hourly schedule hour interval.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByHourly, Mandatory = true, HelpMessage = "The hourly schedule hour interval.")]
+        [ValidateRange(1, byte.MaxValue)]
+        public byte HourInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the weekly schedule week interval.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByWeekly, Mandatory = true, HelpMessage = "The weekly schedule week interval.")]
+        [ValidateRange(1, byte.MaxValue)]
+        public byte WeekInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the weekly schedule week interval.
+        /// </summary>
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByMonthlyDaysOfMonth, Mandatory = true, HelpMessage = "The monthly schedule month interval.")]
+        [Parameter(ParameterSetName = AutomationCmdletParameterSets.ByMonthlyDayOfWeek, Mandatory = true, HelpMessage = "The monthly schedule month interval.")]
+        [ValidateRange(1, byte.MaxValue)]
+        public byte MonthInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schedule time zone.
+        /// </summary>
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "The schedule time zone.")]
+        public string TimeZone { get; set; }
+
+        /// <summary>
         /// Execute this cmdlet.
         /// </summary>
         [PermissionSet(SecurityAction.Demand, Name = "FullTrust")]
         protected override void AutomationProcessRecord()
         {
-            Schedule schedule = this.AutomationClient.UpdateSchedule(
-                this.ResourceGroupName, this.AutomationAccountName, this.Name, this.IsEnabled, this.Description);
+            var recurrence = this.GetRecurrenceInfo();
+            var schedule = this.AutomationClient.UpdateSchedule(
+                this.ResourceGroupName, 
+                this.AutomationAccountName, 
+                this.Name, 
+                this.IsEnabled, 
+                this.Description,
+                this.StartTime,
+                this.ExpiryTime,
+                recurrence.Interval,
+                recurrence.Frequency == null ? null : recurrence.Frequency.ToString(),
+                recurrence.AdvancedSchedule,
+                this.TimeZone);
             this.WriteObject(schedule);
+        }
+
+        /// <summary>
+        /// Gets the recurrence information for this cmdlet.
+        /// </summary>
+        /// <returns>An instance of <see cref="RecurrenceInfo"/> filled with the data passed to the cmdlet.</returns>
+        private RecurrenceInfo GetRecurrenceInfo()
+        {
+            RecurrenceInfo recurrence;
+            switch (this.ParameterSetName)
+            {
+                case AutomationCmdletParameterSets.ByOneTime:
+                    recurrence = this.GetOneTimeRecurrence();
+                    break;
+                case AutomationCmdletParameterSets.ByDaily:
+                    recurrence = this.GetDailyRecurrence();
+                    break;
+                case AutomationCmdletParameterSets.ByHourly:
+                    recurrence = this.GetHourlyRecurrence();
+                    break;
+                case AutomationCmdletParameterSets.ByWeekly:
+                    recurrence = this.GetWeeklyRecurrence();
+                    break;
+                case AutomationCmdletParameterSets.ByMonthlyDayOfWeek:
+                    recurrence = this.GetMonthlyDayOfWeekRecurrence();
+                    break;
+                case AutomationCmdletParameterSets.ByMonthlyDaysOfMonth:
+                    recurrence = this.GetMonthlyDaysOfMonthRecurrence();
+                    break;
+                default:
+                    recurrence = new RecurrenceInfo();
+                    break;
+            }
+            return recurrence;
+        }
+
+        private RecurrenceInfo GetOneTimeRecurrence()
+        {
+            return new RecurrenceInfo
+            {
+                Frequency = ScheduleFrequency.Onetime
+            };
+        }
+
+        private RecurrenceInfo GetHourlyRecurrence()
+        {
+            return new RecurrenceInfo
+            {
+                Frequency = ScheduleFrequency.Hour,
+                Interval = this.HourInterval
+            };
+        }
+
+        private RecurrenceInfo GetDailyRecurrence()
+        {
+            return new RecurrenceInfo
+            {
+                Frequency = ScheduleFrequency.Day,
+                Interval = this.DayInterval
+            };
+        }
+
+        private RecurrenceInfo GetWeeklyRecurrence()
+        {
+            var recurrence = new RecurrenceInfo
+            {
+                Frequency = ScheduleFrequency.Week,
+                Interval = this.WeekInterval
+            };
+
+            if (this.DaysOfWeek != null)
+            {
+                recurrence.AdvancedSchedule = new AdvancedSchedule()
+                {
+                    WeekDays = this.DaysOfWeek.Select(day => day.ToString()).ToList()
+                };
+            }
+
+            return recurrence;
+        }
+
+        private RecurrenceInfo GetMonthlyDayOfWeekRecurrence()
+        {
+            var dayOfWeek = this.DayOfWeek.HasValue ? this.DayOfWeek.ToString() : null;
+            if ((!string.IsNullOrWhiteSpace(dayOfWeek) && this.DayOfWeekOccurrence == 0) || (string.IsNullOrWhiteSpace(dayOfWeek) && this.DayOfWeekOccurrence != 0))
+            {
+                throw new ArgumentException(Resources.MonthlyScheduleNeedsDayOfWeekAndOccurrence);
+            }
+
+            var recurrence = new RecurrenceInfo
+            {
+                Frequency = ScheduleFrequency.Month,
+                Interval = this.MonthInterval
+            };
+
+            if (this.DayOfWeek != null && this.DayOfWeekOccurrence != 0)
+            {
+                recurrence.AdvancedSchedule = new AdvancedSchedule()
+                {
+                    MonthlyOccurrences = new AdvancedScheduleMonthlyOccurrence[]
+                    {
+                        new AdvancedScheduleMonthlyOccurrence()
+                        {
+                            Day = dayOfWeek,
+                            Occurrence = Convert.ToInt32(this.DayOfWeekOccurrence)
+                        }
+                    }
+                };
+            }
+
+            return recurrence;
+        }
+
+        private RecurrenceInfo GetMonthlyDaysOfMonthRecurrence()
+        {
+            var recurrence = new RecurrenceInfo
+            {
+                Frequency = ScheduleFrequency.Month,
+                Interval = this.MonthInterval
+            };
+
+            if (this.DaysOfMonth != null)
+            {
+                recurrence.AdvancedSchedule = new AdvancedSchedule()
+                {
+                    MonthDays = this.DaysOfMonth.Select(v => Convert.ToInt32(v)).ToList()
+                };
+            }
+
+            return recurrence;
+        }
+
+        /// <summary>
+        /// Private class used to group recurrence information.
+        /// </summary>
+        private class RecurrenceInfo
+        {
+            public ScheduleFrequency? Frequency;
+            public byte? Interval;
+            public AdvancedSchedule AdvancedSchedule;
         }
     }
 }

--- a/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
@@ -343,23 +343,14 @@ namespace Microsoft.Azure.Commands.Automation.Common
                     Frequency = schedule.Frequency.ToString(),
                     AdvancedSchedule = schedule.GetAdvancedSchedule(),
                     TimeZone = schedule.TimeZone,
-                }
+                },
+                ConvertTimesFromTimeZone = !string.IsNullOrWhiteSpace(schedule.TimeZone)
             };
 
-            if (!string.IsNullOrEmpty(schedule.TimeZone))
-            {
-                this.automationManagementClient.Schedules.CreateOrUpdateWithTimeConversion(
+            this.automationManagementClient.Schedules.CreateOrUpdate(
                     resourceGroupName,
                     automationAccountName,
                     scheduleCreateOrUpdateParameters);
-            }
-            else
-            {
-                this.automationManagementClient.Schedules.CreateOrUpdate(
-                    resourceGroupName,
-                    automationAccountName,
-                    scheduleCreateOrUpdateParameters);
-            }
 
             return this.GetSchedule(resourceGroupName, automationAccountName, schedule.Name);
         }
@@ -445,7 +436,8 @@ namespace Microsoft.Azure.Commands.Automation.Common
                     Frequency = frequency,
                     AdvancedSchedule = advancedSchedule,
                     TimeZone = timeZone
-                }
+                },
+                ConvertTimesFromTimeZone = !string.IsNullOrWhiteSpace(timeZone)
             };
 
             this.automationManagementClient.Schedules.Patch(

--- a/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AutomationClient.cs
@@ -419,6 +419,43 @@ namespace Microsoft.Azure.Commands.Automation.Common
             return this.UpdateScheduleHelper(resourceGroupName, automationAccountName, scheduleName, isEnabled, description);
         }
 
+        public Schedule UpdateSchedule(
+            string resourceGroupName,
+            string automationAccountName,
+            string scheduleName,
+            bool? isEnabled,
+            string description,
+            DateTimeOffset? startTime,
+            DateTimeOffset? expiryTime,
+            byte? interval,
+            string frequency,
+            AdvancedSchedule advancedSchedule,
+            string timeZone)
+        {
+            var scheduleUpdateParameters = new AutomationManagement.Models.SchedulePatchParameters
+            {
+                Name = scheduleName,
+                Properties = new AutomationManagement.Models.SchedulePatchProperties
+                {
+                    Description = description,
+                    IsEnabled = isEnabled,
+                    StartTime = startTime,
+                    ExpiryTime = expiryTime,
+                    Interval = interval,
+                    Frequency = frequency,
+                    AdvancedSchedule = advancedSchedule,
+                    TimeZone = timeZone
+                }
+            };
+
+            this.automationManagementClient.Schedules.Patch(
+                resourceGroupName,
+                automationAccountName,
+                scheduleUpdateParameters);
+
+            return this.GetSchedule(resourceGroupName, automationAccountName, scheduleName);
+        }
+
         #endregion
 
         #region Runbook Operations

--- a/src/ResourceManager/Automation/Commands.Automation/Common/IAutomationClient.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/IAutomationClient.cs
@@ -183,6 +183,17 @@ namespace Microsoft.Azure.Commands.Automation.Common
 
         Schedule UpdateSchedule(string resourceGroupName, string automationAccountName, string scheduleName, bool? isEnabled, string description);
 
+        Schedule UpdateSchedule(string resourceGroupName, string automationAccountName,
+            string scheduleName,
+            bool? isEnabled,
+            string description,
+            DateTimeOffset? startTime,
+            DateTimeOffset? expiryTime,
+            byte? interval,
+            string frequency,
+            Microsoft.Azure.Management.Automation.Models.AdvancedSchedule advancedSchedule,
+            string timeZone);
+
         #endregion
 
         #region Runbooks

--- a/src/ResourceManager/Automation/Commands.Automation/Microsoft.Azure.Commands.ResourceManager.Automation.dll-help.xml
+++ b/src/ResourceManager/Automation/Commands.Automation/Microsoft.Azure.Commands.ResourceManager.Automation.dll-help.xml
@@ -7563,7 +7563,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
           <maml:name>ExpiryTime</maml:name>
           <maml:description>
-            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffest object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
         </command:parameter>
@@ -7577,7 +7577,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
           <maml:name>TimeZone</maml:name>
           <maml:description>
-            <maml:para>The time zone for the schedule. This string can be the IANNA ID or the Windows Time Zone ID.</maml:para>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         </command:parameter>
@@ -7628,7 +7628,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
           <maml:name>TimeZone</maml:name>
           <maml:description>
-            <maml:para>The time zone for the schedule. This string can be the IANNA ID or the Windows Time Zone ID.</maml:para>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         </command:parameter>
@@ -7673,7 +7673,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
           <maml:name>ExpiryTime</maml:name>
           <maml:description>
-            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffest object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
         </command:parameter>
@@ -7687,7 +7687,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
           <maml:name>TimeZone</maml:name>
           <maml:description>
-            <maml:para>The time zone for the schedule. This string can be the IANNA ID or the Windows Time Zone ID.</maml:para>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         </command:parameter>
@@ -7732,7 +7732,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
           <maml:name>ExpiryTime</maml:name>
           <maml:description>
-            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffest object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
         </command:parameter>
@@ -7753,7 +7753,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
           <maml:name>TimeZone</maml:name>
           <maml:description>
-            <maml:para>The time zone for the schedule. This string can be the IANNA ID or the Windows Time Zone ID.</maml:para>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         </command:parameter>
@@ -7798,7 +7798,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
           <maml:name>ExpiryTime</maml:name>
           <maml:description>
-            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffest object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
         </command:parameter>
@@ -7819,7 +7819,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
           <maml:name>TimeZone</maml:name>
           <maml:description>
-            <maml:para>The time zone for the schedule. This string can be the IANNA ID or the Windows Time Zone ID.</maml:para>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         </command:parameter>
@@ -7864,7 +7864,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
           <maml:name>ExpiryTime</maml:name>
           <maml:description>
-            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffest object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
         </command:parameter>
@@ -7892,7 +7892,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
           <maml:name>TimeZone</maml:name>
           <maml:description>
-            <maml:para>The time zone for the schedule. This string can be the IANNA ID or the Windows Time Zone ID.</maml:para>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         </command:parameter>
@@ -7938,7 +7938,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
         <maml:name>ExpiryTime</maml:name>
         <maml:description>
-          <maml:para>Specifies the expiry time of a schedule as a DateTimeOffest object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
         <dev:type>
@@ -8022,7 +8022,7 @@ PS C:\&gt; New-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
       <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
         <maml:name>MonthInterval</maml:name>
         <maml:description>
-          <maml:para>Specifies an interval, in moonths, for the schedule.</maml:para>
+          <maml:para>Specifies an interval, in months, for the schedule.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
         <dev:type>
@@ -12792,6 +12792,450 @@ PS C:\&gt; Set-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
           </maml:description>
           <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>StartTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the start time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>ExpiryTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>TimeZone</maml:name>
+          <maml:description>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-AzureRMAutomationSchedule</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="1" aliases="none">
+          <maml:name>ResourceGroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of a resource group for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="2" aliases="none">
+          <maml:name>AutomationAccountName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of an Automation account for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name for the schedule that this cmdlet modifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>OneTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies that the cmdlet sets the schedule to run one-time.</maml:para>
+          </maml:description>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Specifies a description for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>IsEnabled</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether this cmdlet enables the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>StartTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the start time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>ExpiryTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>TimeZone</maml:name>
+          <maml:description>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-AzureRMAutomationSchedule</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="1" aliases="none">
+          <maml:name>ResourceGroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of a resource group for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="2" aliases="none">
+          <maml:name>AutomationAccountName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of an Automation account for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name for the schedule that this cmdlet modifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>HourInterval</maml:name>
+          <maml:description>
+            <maml:para>Specifies an interval, in hours, for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Specifies a description for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>IsEnabled</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether this cmdlet enables the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>StartTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the start time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>ExpiryTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>TimeZone</maml:name>
+          <maml:description>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-AzureRMAutomationSchedule</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="1" aliases="none">
+          <maml:name>ResourceGroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of a resource group for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="2" aliases="none">
+          <maml:name>AutomationAccountName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of an Automation account for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name for the schedule that this cmdlet modifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>DayInterval</maml:name>
+          <maml:description>
+            <maml:para>Specifies an interval, in days, for the schedule. If you do not specify this parameter, and you do not specify the OneTime parameter, the default value is one (1).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Specifies a description for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>IsEnabled</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether this cmdlet enables the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>StartTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the start time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>ExpiryTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>TimeZone</maml:name>
+          <maml:description>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-AzureRMAutomationSchedule</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="1" aliases="none">
+          <maml:name>ResourceGroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of a resource group for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="2" aliases="none">
+          <maml:name>AutomationAccountName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of an Automation account for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name for the schedule that this cmdlet modifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>WeekInterval</maml:name>
+          <maml:description>
+            <maml:para>Specifies an interval, in weeks, for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>DaysOfWeek</maml:name>
+          <maml:description>
+            <maml:para>The list of days of week for the weekly schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">System.DayOfWeek[]</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Specifies a description for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>IsEnabled</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether this cmdlet enables the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>StartTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the start time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>ExpiryTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>TimeZone</maml:name>
+          <maml:description>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-AzureRMAutomationSchedule</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="1" aliases="none">
+          <maml:name>ResourceGroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of a resource group for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="2" aliases="none">
+          <maml:name>AutomationAccountName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of an Automation account for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name for the schedule that this cmdlet modifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>MonthInterval</maml:name>
+          <maml:description>
+            <maml:para>Specifies an interval, in Month, for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>DaysOfMonth</maml:name>
+          <maml:description>
+            <maml:para>The list of days of month for the monthly schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">System.Int32[]</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Specifies a description for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>IsEnabled</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether this cmdlet enables the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>StartTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the start time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>ExpiryTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>TimeZone</maml:name>
+          <maml:description>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-AzureRMAutomationSchedule</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="1" aliases="none">
+          <maml:name>ResourceGroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of a resource group for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="2" aliases="none">
+          <maml:name>AutomationAccountName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of an Automation account for which this cmdlet modifies a schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="3" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name for the schedule that this cmdlet modifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>MonthInterval</maml:name>
+          <maml:description>
+            <maml:para>Specifies an interval, in Month, for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>DayOfWeek</maml:name>
+          <maml:description>
+            <maml:para>The day of week for the monthly occurrence.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">System.DayOfWeek</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+          <maml:name>DayOfWeekOccurrence</maml:name>
+          <maml:description>
+            <maml:para>The Occurrence of the week within the month.The acceptable values either are 1, 2, 3, 4, -1 or First, Second, Third, Fourth and LastDay</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">System.Int32</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Specifies a description for the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>IsEnabled</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether this cmdlet enables the schedule.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>StartTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the start time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>ExpiryTime</maml:name>
+          <maml:description>
+            <maml:para>Specifies the expiry time of a schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+          <maml:name>TimeZone</maml:name>
+          <maml:description>
+            <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -12855,6 +13299,137 @@ PS C:\&gt; Set-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
         </dev:type>
         <dev:defaultValue>none</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>DayInterval</maml:name>
+        <maml:description>
+          <maml:para>Specifies an interval, in days, for the schedule.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        <dev:type>
+          <maml:name>Byte</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+        <maml:name>ExpiryTime</maml:name>
+        <maml:description>
+          <maml:para>Specifies the expiry time of the schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DateTimeOffset</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTimeOffset</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>HourInterval</maml:name>
+        <maml:description>
+          <maml:para>Specifies an interval, in hours, for the schedule.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        <dev:type>
+          <maml:name>Byte</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>OneTime</maml:name>
+        <maml:description>
+          <maml:para>Specifies that the cmdlet sets the schedule to run one-time.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="4" aliases="none">
+        <maml:name>StartTime</maml:name>
+        <maml:description>
+          <maml:para>Specifies the start time of the schedule as a DateTimeOffset object. You can specify a string that can be converted to a valid DateTimeOffset.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DateTimeOffset</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTimeOffset</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>WeekInterval</maml:name>
+        <maml:description>
+          <maml:para>Specifies an interval, in weeks, for the schedule.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        <dev:type>
+          <maml:name>Byte</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>MonthInterval</maml:name>
+        <maml:description>
+          <maml:para>Specifies an interval, in months, for the schedule.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Byte</command:parameterValue>
+        <dev:type>
+          <maml:name>Byte</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>DaysOfWeek</maml:name>
+        <maml:description>
+          <maml:para>The list of days of week for the weekly schedule.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">System.DayOfWeek[]</command:parameterValue>
+        <dev:type>
+          <maml:name>System.DayOfWeek[]</maml:name>
+          <maml:uri />
+        </dev:type>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>DayOfWeek</maml:name>
+        <maml:description>
+          <maml:para>The day of week for the monthly occurrence.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">System.DayOfWeek</command:parameterValue>
+        <dev:type>
+          <maml:name>System.DayOfWeek</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named" aliases="none">
+        <maml:name>DayOfWeekOccurrence</maml:name>
+        <maml:description>
+          <maml:para>The Occurrence of the week within the month.The acceptable values either are 1, 2, 3, 4, -1 or First, Second, Third, Fourth and LastDay</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">System.Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="true(ByPropertyName)" position="named" aliases="none">
+        <maml:name>TimeZone</maml:name>
+        <maml:description>
+          <maml:para>The time zone for the schedule. This string can be the IANA ID or the Windows Time Zone ID.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>none</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes>
       <command:inputType>
@@ -12889,7 +13464,7 @@ PS C:\&gt; Set-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
     <command:nonTerminatingErrors />
     <command:examples>
       <command:example>
-        <maml:title>Example 1: Modify a schedule</maml:title>
+        <maml:title>Example 1: Modify the description of a schedule</maml:title>
         <maml:introduction>
           <maml:para>
           </maml:para>
@@ -12898,6 +13473,74 @@ PS C:\&gt; Set-AzureRmAutomationCredential -AutomationAccountName "Contoso17" -N
 </dev:code>
         <dev:remarks>
           <maml:para>This command modifies the description of the schedule named Schedule01.</maml:para>
+          <maml:para />
+          <maml:para />
+        </dev:remarks>
+        <command:commandLines>
+          <command:commandLine>
+            <command:commandText />
+          </command:commandLine>
+        </command:commandLines>
+      </command:example>
+      <command:example>
+        <maml:title>Example 2: Modify the expiration date of a schedule</maml:title>
+        <maml:introduction>
+          <maml:para>
+          </maml:para>
+        </maml:introduction>
+        <dev:code>
+PS C:\&gt; $StartTime = Get-Date
+PS C:\&gt; $EndTime = $StartTime.AddYears(1)
+PS C:\&gt; Set-AzureRmAutomationSchedule -AutomationAccountName "Contoso17" -Name "Schedule02" -ExpiryTime $EndTime -ResourceGroupName "ResourceGroup01"
+</dev:code>
+        <dev:remarks>
+          <maml:para>The first command creates a date object by using the Get-Date cmdlet, and then stores the object in the $StartDate variable.</maml:para>
+          <maml:para>The second command creates a date object by using the Get-Date cmdlet, and then stores the object in the $EndDate variable. The command specifies a future time. </maml:para>
+          <maml:para>The final command modifies the schedule named Schedule02 expire at the time stored in $EndDate.</maml:para>
+          <maml:para />
+          <maml:para />
+        </dev:remarks>
+        <command:commandLines>
+          <command:commandLine>
+            <command:commandText />
+          </command:commandLine>
+        </command:commandLines>
+      </command:example>
+      <command:example>
+        <maml:title>Example 3: Modify a schedule to recur Weekly</maml:title>
+        <maml:introduction>
+          <maml:para>
+          </maml:para>
+        </maml:introduction>
+        <dev:code>
+PS C:\&gt; $days = @([System.DayOfWeek]::Monday, [System.DayOfWeek]::Saturday, [System.DayOfWeek]::Sunday)
+PS C:\&gt; Set-AzureRmAutomationSchedule -AutomationAccountName "Contoso17" -Name "Schedule03" -WeeklyInterval 1 -DaysOfWeek $days -ResourceGroupName "ResourceGroup01"
+</dev:code>
+        <dev:remarks>
+          <maml:para>The first command creates an array of selected System.DayOfWeek in which the schedule is set to be run, and then stores the object in the $days variable.</maml:para>
+          <maml:para>The final command modifies the schedule named Schedule03 to run in the days of the week stored in $days.</maml:para>
+          <maml:para />
+          <maml:para />
+        </dev:remarks>
+        <command:commandLines>
+          <command:commandLine>
+            <command:commandText />
+          </command:commandLine>
+        </command:commandLines>
+      </command:example>
+      <command:example>
+        <maml:title>Example 4: Modify the start time of a schedule</maml:title>
+        <maml:introduction>
+          <maml:para>
+          </maml:para>
+        </maml:introduction>
+        <dev:code>          
+PS C:\&gt; $StartTime = (Get-Date).AddMinutes(15)
+PS C:\&gt; Set-AzureRmAutomationSchedule -AutomationAccountName "Contoso17" -Name "Schedule04" -StartTime $StartTime -ResourceGroupName "ResourceGroup01"
+</dev:code>
+        <dev:remarks>
+          <maml:para>The first command creates a date object by using the Get-Date cmdlet, adds 15 minutes, and then stores the object in the $StartDate variable. Specify a time that is at least five minutes in the future.</maml:para>
+          <maml:para>The final command modifies the schedule named Schedule04 to begin at the time stored in $StartDate.</maml:para>
           <maml:para />
           <maml:para />
         </dev:remarks>


### PR DESCRIPTION
Set-AzureRmAutomationSchedule allows updating of all properties

Both New-AzureRmAutomationSchedule and Set-AzureRmAutomationSchedule send the ConvertTimesFromTimeZone flag when the TimeZone is set. If not set, times are in UTC